### PR TITLE
feat: add queue-enabled Reef Controls UI and steer SysId routines

### DIFF
--- a/src/main/deploy/reefcontrols/index.css
+++ b/src/main/deploy/reefcontrols/index.css
@@ -1,306 +1,636 @@
+:root {
+  --shell-max-width: 1200px;
+  --shell-gap: clamp(1rem, 1.8vw, 2.4rem);
+  --panel-bg: rgba(5, 14, 29, 0.72);
+  --panel-bg-strong: rgba(7, 16, 32, 0.9);
+  --panel-border: rgba(255, 255, 255, 0.14);
+  --panel-border-strong: rgba(255, 255, 255, 0.35);
+  --glow: 0 25px 50px rgba(2, 8, 20, 0.55);
+  --text-dim: rgba(245, 251, 255, 0.7);
+  --accent: #4fd0ff;
+  --accent-strong: #ff8df2;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
 body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  font-size: clamp(14px, 1vw + 10px, 18px);
   overscroll-behavior: none;
   overflow: hidden;
-  font-family: Helvetica, sans-serif;
   user-select: none;
   -webkit-user-select: none;
   cursor: default;
-  color: #000;
-
-  /* Show disconnected state by default */
-  background-color: red;
+  color: #f4fbff;
+  background-color: #0b2845; /* overwritten to indicate state */
+  background-image: radial-gradient(
+      circle at 20% 20%,
+      rgba(255, 255, 255, 0.08),
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at 80% 0%,
+      rgba(255, 255, 255, 0.12),
+      transparent 60%
+    ),
+    linear-gradient(145deg, #040d1c, #071832 55%, #0c2542);
+  background-repeat: no-repeat;
+  padding: clamp(0.5rem, 1.5vw, 1.5rem);
+  transition: background-color 250ms ease;
 }
 
-div {
-  position: absolute;
+.app-shell {
+  width: min(var(--shell-max-width), 100%);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--shell-gap);
 }
 
-div.overview-section {
-  top: 0%;
-  left: 0%;
-  height: 100%;
-  width: 15%;
+.app-header {
+  background: rgba(6, 12, 23, 0.65);
+  border: 1px solid var(--panel-border);
+  border-radius: 1.75rem;
+  padding: clamp(1rem, 2vw, 2rem);
+  box-shadow: var(--glow);
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
-div.overview-section div.counter-container {
-  left: 0%;
+.app-title {
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.app-subtitle {
+  font-size: clamp(1rem, 1.5vw, 1.2rem);
+  color: var(--text-dim);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.main-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2.3fr) minmax(280px, 1fr);
+  gap: var(--shell-gap);
+  align-items: start;
+}
+
+.primary-column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--shell-gap);
+  min-width: 0;
+}
+
+.overview-section {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 1.5rem;
+  padding: clamp(1rem, 1vw, 1.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.8rem, 1.5vh, 1.4rem);
+  box-shadow: var(--glow);
+}
+
+.counter-container {
   width: 100%;
-  height: 25%;
 }
 
-div.overview-section div.counter-container:nth-child(1) {
-  top: 75%;
-}
-
-div.overview-section div.counter-container:nth-child(2) {
-  top: 50%;
-}
-
-div.overview-section div.counter-container:nth-child(3) {
-  top: 25%;
-}
-
-div.overview-section div.counter-container:nth-child(4) {
-  top: 0%;
-}
-
-div.overview-section div.counter-container div.counter-area {
-  top: 10%;
-  height: 80%;
-  left: 10%;
-  width: 80%;
-  border-radius: 5vh;
-  border: 1px solid #333;
-}
-
-div.overview-section div.counter-container div.counter-area.active {
-  background-color: #ffffff;
-}
-
-div.overview-section div.counter-container div.counter-area div {
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  font-size: 10vh;
-}
-
-div.reef-section {
-  top: 0%;
-  left: 15%;
-  height: 80%;
-  width: 85%;
-}
-
-div.reef-section canvas {
-  position: absolute;
-  left: 0%;
-  top: 0%;
+.counter-area {
   width: 100%;
-  height: 100%;
+  min-height: 6rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--panel-border);
+  border-radius: 1.2rem;
+  padding: 1.1rem 0.8rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  text-align: center;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+  transition: transform 180ms ease, border-color 180ms ease,
+    box-shadow 180ms ease, background 180ms ease;
+}
+
+.counter {
+  font-size: clamp(2.1rem, 5vh, 3rem);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-shadow: 0 12px 25px rgba(0, 0, 0, 0.35);
+}
+
+.counter-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  color: var(--text-dim);
+}
+
+.counter-area.active {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: var(--panel-border-strong);
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.45);
+  transform: translateY(-4px);
+}
+
+.reef-section {
+  position: relative;
+  border-radius: 1.9rem;
+  border: 1px solid var(--panel-border);
+  background: var(--panel-bg-strong);
+  box-shadow: var(--glow);
+  overflow: hidden;
+  min-height: clamp(420px, 55vh, 640px);
+}
+
+.reef-section::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at 30% 20%,
+    rgba(255, 255, 255, 0.1),
+    transparent 60%
+  );
+  pointer-events: none;
   z-index: 0;
 }
 
-div.reef-section div.branch,
-div.reef-section div.algae {
-  border-radius: 100%;
-  transform: translate(-50%, -50%);
-  border: 1px solid #333;
+.reef-section canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   z-index: 1;
+  opacity: 0.7;
 }
 
-div.reef-section div.branch {
-  height: 12vh;
+.reef-section .branch,
+.reef-section .algae {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 25px rgba(0, 0, 0, 0.35),
+    0 6px 15px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  transition: transform 160ms ease, box-shadow 160ms ease,
+    border-color 160ms ease, background 160ms ease;
+  z-index: 2;
+}
+
+.reef-section .branch {
   width: 12vh;
+  height: 12vh;
 }
 
-div.reef-section div.algae {
-  height: 14vh;
+.reef-section .algae {
   width: 14vh;
+  height: 14vh;
 }
 
-div.reef-section div.branch {
-  background-color: #f4c9ff;
-}
-
-div.reef-section div.branch.active {
-  background-color: #cc00ff;
-}
-
-div.reef-section div.branch img {
+.reef-section .branch img,
+.reef-section .algae img {
+  width: 70%;
+  pointer-events: none;
   display: none;
+}
+
+.reef-section .branch.active img,
+.reef-section .algae.active img {
+  display: block;
+}
+
+.reef-section .branch.active {
+  background-image: linear-gradient(145deg, #fdd5ff, #be63ff);
+  border-color: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 0 30px rgba(212, 119, 255, 0.65);
+  transform: translate(-50%, -50%) scale(1.02);
+}
+
+.reef-section .algae.active {
+  background-image: linear-gradient(145deg, #b5f5ff, #04befe);
+  border-color: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 0 32px rgba(0, 187, 255, 0.55);
+}
+
+.reef-section .branch:hover,
+.reef-section .algae:hover {
+  transform: translate(-50%, -50%) scale(1.04);
+}
+
+.reef-section .flag {
   position: absolute;
   left: 50%;
   top: 50%;
-  transform: translate(-50%, -50%);
-  width: 10vh;
+  transform: translate(-50%, -50%) scale(1);
+  font-size: clamp(4rem, 12vh, 6rem);
+  z-index: 4;
+  text-shadow: 0 15px 30px rgba(0, 0, 0, 0.6);
 }
 
-div.reef-section div.branch.active img {
-  display: initial;
-}
-
-div.reef-section div.algae {
-  background-color: #c6efff;
-}
-
-div.reef-section div.algae.active {
-  background-color: #00b7ff;
-}
-
-div.reef-section div.algae img {
-  display: none;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  width: 10vh;
-}
-
-div.reef-section div.algae.active img {
-  display: initial;
-}
-
-div.reef-section div.branch:nth-child(1) {
+/* Reef layout (matches the original geometry) */
+.reef-section .branch:nth-child(1) {
   left: calc(50% + 10%);
   top: calc(50% + 40%);
 }
-
-div.reef-section div.branch:nth-child(2) {
+.reef-section .branch:nth-child(2) {
   left: calc(50% - 10%);
   top: calc(50% + 40%);
 }
-
-div.reef-section div.branch:nth-child(3) {
+.reef-section .branch:nth-child(3) {
   left: calc(50% - 30%);
   top: calc(50% + 30%);
 }
-
-div.reef-section div.branch:nth-child(4) {
+.reef-section .branch:nth-child(4) {
   left: calc(50% - 40%);
   top: calc(50% + 12%);
 }
-
-div.reef-section div.branch:nth-child(5) {
+.reef-section .branch:nth-child(5) {
   left: calc(50% - 40%);
   top: calc(50% - 12%);
 }
-
-div.reef-section div.branch:nth-child(6) {
+.reef-section .branch:nth-child(6) {
   left: calc(50% - 30%);
   top: calc(50% - 30%);
 }
-
-div.reef-section div.branch:nth-child(7) {
+.reef-section .branch:nth-child(7) {
   left: calc(50% - 10%);
   top: calc(50% - 40%);
 }
-
-div.reef-section div.branch:nth-child(8) {
+.reef-section .branch:nth-child(8) {
   left: calc(50% + 10%);
   top: calc(50% - 40%);
 }
-
-div.reef-section div.branch:nth-child(9) {
+.reef-section .branch:nth-child(9) {
   left: calc(50% + 30%);
   top: calc(50% - 30%);
 }
-
-div.reef-section div.branch:nth-child(10) {
+.reef-section .branch:nth-child(10) {
   left: calc(50% + 40%);
   top: calc(50% - 12%);
 }
-
-div.reef-section div.branch:nth-child(11) {
+.reef-section .branch:nth-child(11) {
   left: calc(50% + 40%);
   top: calc(50% + 12%);
 }
-
-div.reef-section div.branch:nth-child(12) {
+.reef-section .branch:nth-child(12) {
   left: calc(50% + 30%);
   top: calc(50% + 30%);
 }
 
-div.reef-section div.algae:nth-child(13) {
+.reef-section .algae:nth-child(13) {
   left: calc(50% + 0%);
   top: calc(50% + 20%);
 }
-
-div.reef-section div.algae:nth-child(14) {
+.reef-section .algae:nth-child(14) {
   left: calc(50% - 18%);
   top: calc(50% + 10%);
 }
-
-div.reef-section div.algae:nth-child(15) {
+.reef-section .algae:nth-child(15) {
   left: calc(50% - 18%);
   top: calc(50% - 10%);
 }
-
-div.reef-section div.algae:nth-child(16) {
+.reef-section .algae:nth-child(16) {
   left: calc(50% + 0%);
   top: calc(50% - 20%);
 }
-
-div.reef-section div.algae:nth-child(17) {
+.reef-section .algae:nth-child(17) {
   left: calc(50% + 18%);
   top: calc(50% - 10%);
 }
-
-div.reef-section div.algae:nth-child(18) {
+.reef-section .algae:nth-child(18) {
   left: calc(50% + 18%);
   top: calc(50% + 10%);
 }
 
-div.reef-section div.flag {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  font-size: 12vh;
-  z-index: 1;
+.queue-section {
+  width: 100%;
+  align-self: stretch;
 }
 
-div.lower-section {
-  top: 80%;
-  left: 15%;
-  height: 20%;
-  width: 85%;
+.queue-panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 1.5rem;
+  padding: clamp(1rem, 1.5vw, 2rem);
+  box-shadow: var(--glow);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.75rem, 1vw, 1.4rem);
+  min-height: 100%;
 }
 
-div.lower-section div.subtract,
-div.lower-section div.add,
-div.lower-section div.coop {
-  top: 10%;
-  height: 80%;
-  width: 25%;
-  border-radius: 5vh;
-  border: 1px solid #333;
+.queue-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
-div.lower-section div.subtract {
-  left: 7%;
+.queue-title {
+  font-size: clamp(1.2rem, 2vw, 1.6rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
 }
 
-div.lower-section div.add {
-  left: 34%;
+.queue-subtitle {
+  font-size: 0.85rem;
+  color: var(--text-dim);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
 }
 
-div.lower-section div.coop {
-  left: 68%;
+.queue-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
 }
 
-div.lower-section div.coop.active {
-  background-color: #00b7ff;
+.queue-control {
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  padding: 0.45rem 1.2rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease, transform 150ms ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
-div.lower-section div.subtract div,
-div.lower-section div.add div {
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  font-size: 10vh;
-  filter: brightness(0);
+.queue-control:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: var(--panel-border-strong);
+  transform: translateY(-1px);
 }
 
-div.lower-section div.coop div {
+.queue-control.queue-control-active {
+  border-color: var(--accent);
+  color: #fff;
+  background: rgba(79, 208, 255, 0.18);
+  box-shadow: 0 0 20px rgba(79, 208, 255, 0.25);
+}
+
+.queue-control:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.queue-hint {
+  font-size: 0.9rem;
+  color: var(--text-dim);
+  line-height: 1.4;
+}
+
+.queue-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.queue-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.queue-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1.1rem;
+  padding: 0.85rem 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  gap: 0.75rem;
+  cursor: grab;
+  position: relative;
+}
+
+.queue-item > div:first-child {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.queue-item-title {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.queue-item-meta {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.queue-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.queue-status-badge {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.04);
+  letter-spacing: 0.1em;
+}
+
+.queue-remove {
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.queue-placeholder {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px dashed rgba(255, 255, 255, 0.25);
+  color: var(--text-dim);
+  font-size: 0.9rem;
+}
+
+.queue-item.status-active {
+  border-color: var(--accent);
+  background: rgba(79, 208, 255, 0.08);
+}
+
+.queue-item.status-done {
+  opacity: 0.75;
+}
+
+.queue-item.status-ready {
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.queue-item.dragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
+.queue-list.queue-dragging .queue-item:not(.dragging) {
+  opacity: 0.7;
+}
+
+.queue-status-panel {
+  border: 1px dashed var(--panel-border);
+  border-radius: 1rem;
+  padding: 0.8rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.queue-phase {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+}
+
+.queue-sync {
+  font-size: 0.75rem;
+  color: var(--accent);
+}
+
+.queue-message {
+  font-size: 0.9rem;
+  color: var(--text-dim);
+}
+
+.queue-active {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.lower-section {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 1.5rem;
+  padding: clamp(1rem, 1.8vw, 1.75rem);
+  box-shadow: var(--glow);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(0.85rem, 1.5vw, 1.8rem);
+}
+
+.lower-section > div {
+  position: relative;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--panel-border);
+  border-radius: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: clamp(120px, 18vh, 150px);
+  gap: 0.4rem;
+  color: #fff;
+  font-size: clamp(2.3rem, 7vh, 3.2rem);
+  box-shadow: 0 12px 25px rgba(0, 0, 0, 0.35);
+  transition: transform 160ms ease, border-color 160ms ease,
+    box-shadow 160ms ease, background 160ms ease;
+}
+
+.lower-section .button-icon {
+  line-height: 1;
+}
+
+.lower-section .coop .button-icon {
   display: none;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  font-size: 12vh;
 }
 
-div.lower-section div.coop.active div {
-  display: initial;
+.lower-section .coop.active .button-icon {
+  display: block;
 }
 
-body.elims div.lower-section div.subtract {
-  left: 24%;
+.lower-section > div .button-label {
+  font-size: 0.95rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--text-dim);
 }
 
-body.elims div.lower-section div.add {
-  left: 51%;
+.lower-section > div:hover {
+  transform: translateY(-3px);
+  border-color: var(--panel-border-strong);
 }
 
-body.elims div.lower-section div.coop {
+.lower-section .coop.active {
+  background: rgba(79, 208, 255, 0.15);
+  border-color: var(--accent);
+  box-shadow: 0 12px 30px rgba(79, 208, 255, 0.4);
+}
+
+body.elims .lower-section {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+body.elims .lower-section .coop {
   display: none;
+}
+
+@media (max-width: 960px) {
+  body {
+    overflow-y: auto;
+  }
+
+  .main-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .queue-panel {
+    min-height: auto;
+  }
+
+  .reef-section {
+    min-height: 60vh;
+  }
 }

--- a/src/main/deploy/reefcontrols/index.html
+++ b/src/main/deploy/reefcontrols/index.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta
@@ -11,46 +12,133 @@
     <title>Reef Controls &mdash; FRC 1884</title>
   </head>
   <body>
-    <div class="overview-section">
-      <div class="counter-container">
-        <div class="counter-area"><div class="counter">0</div></div>
-      </div>
-      <div class="counter-container">
-        <div class="counter-area"><div class="counter">0</div></div>
-      </div>
-      <div class="counter-container">
-        <div class="counter-area"><div class="counter">0</div></div>
-      </div>
-      <div class="counter-container">
-        <div class="counter-area"><div class="counter">0</div></div>
-      </div>
-    </div>
-    <div class="reef-section">
-      <div class="branch"><img src="coral.png" /></div>
-      <div class="branch"><img src="coral.png" /></div>
-      <div class="branch"><img src="coral.png" /></div>
-      <div class="branch"><img src="coral.png" /></div>
-      <div class="branch"><img src="coral.png" /></div>
-      <div class="branch"><img src="coral.png" /></div>
-      <div class="branch"><img src="coral.png" /></div>
-      <div class="branch"><img src="coral.png" /></div>
-      <div class="branch"><img src="coral.png" /></div>
-      <div class="branch"><img src="coral.png" /></div>
-      <div class="branch"><img src="coral.png" /></div>
-      <div class="branch"><img src="coral.png" /></div>
-      <div class="algae active"><img src="algae.png" /></div>
-      <div class="algae active"><img src="algae.png" /></div>
-      <div class="algae active"><img src="algae.png" /></div>
-      <div class="algae active"><img src="algae.png" /></div>
-      <div class="algae active"><img src="algae.png" /></div>
-      <div class="algae active"><img src="algae.png" /></div>
-      <div class="flag" hidden>&#x1F3C1;</div>
-      <canvas class="reef-canvas"></canvas>
-    </div>
-    <div class="lower-section">
-      <div class="subtract"><div>&#x2796;</div></div>
-      <div class="add"><div>&#x2795;</div></div>
-      <div class="coop"><div>&#x1F91D;</div></div>
+    <div class="app-shell">
+      <header class="app-header">
+        <div class="app-title">Reef Controls</div>
+        <div class="app-subtitle">FRC 1884</div>
+      </header>
+      <main class="main-layout">
+        <div class="primary-column">
+          <section class="overview-section">
+            <div class="counter-container">
+              <div class="counter-area">
+                <div class="counter">0</div>
+                <div class="counter-label">L1</div>
+              </div>
+            </div>
+            <div class="counter-container">
+              <div class="counter-area">
+                <div class="counter">0</div>
+                <div class="counter-label">L2</div>
+              </div>
+            </div>
+            <div class="counter-container">
+              <div class="counter-area">
+                <div class="counter">0</div>
+                <div class="counter-label">L3</div>
+              </div>
+            </div>
+            <div class="counter-container">
+              <div class="counter-area">
+                <div class="counter">0</div>
+                <div class="counter-label">L4</div>
+              </div>
+            </div>
+          </section>
+          <section class="reef-section">
+            <div class="branch"><img src="coral.png" alt="Coral position" /></div>
+            <div class="branch"><img src="coral.png" alt="Coral position" /></div>
+            <div class="branch"><img src="coral.png" alt="Coral position" /></div>
+            <div class="branch"><img src="coral.png" alt="Coral position" /></div>
+            <div class="branch"><img src="coral.png" alt="Coral position" /></div>
+            <div class="branch"><img src="coral.png" alt="Coral position" /></div>
+            <div class="branch"><img src="coral.png" alt="Coral position" /></div>
+            <div class="branch"><img src="coral.png" alt="Coral position" /></div>
+            <div class="branch"><img src="coral.png" alt="Coral position" /></div>
+            <div class="branch"><img src="coral.png" alt="Coral position" /></div>
+            <div class="branch"><img src="coral.png" alt="Coral position" /></div>
+            <div class="branch"><img src="coral.png" alt="Coral position" /></div>
+            <div class="algae active">
+              <img src="algae.png" alt="Algae position" />
+            </div>
+            <div class="algae active">
+              <img src="algae.png" alt="Algae position" />
+            </div>
+            <div class="algae active">
+              <img src="algae.png" alt="Algae position" />
+            </div>
+            <div class="algae active">
+              <img src="algae.png" alt="Algae position" />
+            </div>
+            <div class="algae active">
+              <img src="algae.png" alt="Algae position" />
+            </div>
+            <div class="algae active">
+              <img src="algae.png" alt="Algae position" />
+            </div>
+            <div class="flag" hidden aria-label="Ranking point earned">
+              &#x1F3C1;
+            </div>
+            <canvas class="reef-canvas" aria-hidden="true"></canvas>
+          </section>
+          <section class="lower-section">
+            <div class="subtract">
+              <div class="button-icon" aria-hidden="true">&#x2796;</div>
+              <div class="button-label">-1 Algae</div>
+            </div>
+            <div class="add">
+              <div class="button-icon" aria-hidden="true">&#x2795;</div>
+              <div class="button-label">+1 Algae</div>
+            </div>
+            <div class="coop">
+              <div class="button-icon" aria-hidden="true">&#x1F91D;</div>
+              <div class="button-label">Co-Op</div>
+            </div>
+          </section>
+        </div>
+        <section class="queue-section">
+          <div class="queue-panel">
+            <div class="queue-header">
+              <div>
+                <div class="queue-title">Tablet Queue</div>
+                <div class="queue-subtitle">Plan the robot's next moves</div>
+              </div>
+              <div class="queue-controls">
+                <button type="button" class="queue-control queue-manual" id="queue-manual-toggle">
+                  Disable Queue
+                </button>
+                <button type="button" class="queue-control" data-queue-command="start">
+                  Start
+                </button>
+                <button type="button" class="queue-control" data-queue-command="stop">
+                  Pause
+              </button>
+              <button type="button" class="queue-control" data-queue-command="skip">
+                Skip
+              </button>
+              <button type="button" class="queue-control" data-queue-command="reset">
+                Reset
+              </button>
+            </div>
+          </div>
+          <div class="queue-hint">
+            Tap reef nodes to enqueue a source &rarr; reef pair for the selected level, then hit
+            Start. Drag items to reorder them, tap to remove, and toggle manual mode when the driver
+            needs hands-on control.
+          </div>
+          <div class="queue-body">
+            <ul id="queue-plan" class="queue-list"></ul>
+            <div class="queue-status-panel">
+              <div class="queue-phase">
+                <span id="queue-phase">IDLE</span>
+                <span id="queue-sync-indicator" class="queue-sync" hidden>Idle</span>
+              </div>
+              <div id="queue-message" class="queue-message">Waiting for queue...</div>
+              <div id="queue-active-step" class="queue-active">Active Step: --</div>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
   </body>
 </html>

--- a/src/main/deploy/reefcontrols/index.js
+++ b/src/main/deploy/reefcontrols/index.js
@@ -19,6 +19,9 @@ const l4TopicName = "Level4";
 const algaeTopicName = "Algae";
 const coopTopicName = "Coop";
 const isElimsTopicName = "IsElims";
+const queueSpecTopicName = "QueueSpec";
+const queueCommandTopicName = "QueueCommand";
+const queueStateTopicName = "QueueState";
 
 const ntClient = new NT4_Client(
   window.location.hostname,
@@ -32,7 +35,7 @@ const ntClient = new NT4_Client(
   (topic, _, value) => {
     // New data
     if (topic.name === toDashboardPrefix + selectedLevelTopicName) {
-      selectedLevel = value;
+      selectedLevel = clampSelectedLevel(value);
     } else if (topic.name === toDashboardPrefix + l1TopicName) {
       l1State = value;
     } else if (topic.name === toDashboardPrefix + l2TopicName) {
@@ -47,6 +50,10 @@ const ntClient = new NT4_Client(
       coopState = value;
     } else if (topic.name === toDashboardPrefix + isElimsTopicName) {
       isElims = value;
+    } else if (topic.name === toDashboardPrefix + queueStateTopicName) {
+      if (typeof value === "string") {
+        applyQueueState(value);
+      }
     } else {
       return;
     }
@@ -73,6 +80,7 @@ window.addEventListener("load", () => {
       toDashboardPrefix + algaeTopicName,
       toDashboardPrefix + coopTopicName,
       toDashboardPrefix + isElimsTopicName,
+      toDashboardPrefix + queueStateTopicName,
     ],
     false,
     false,
@@ -86,12 +94,14 @@ window.addEventListener("load", () => {
   ntClient.publishTopic(toRobotPrefix + l4TopicName, "int");
   ntClient.publishTopic(toRobotPrefix + algaeTopicName, "int");
   ntClient.publishTopic(toRobotPrefix + coopTopicName, "boolean");
+  ntClient.publishTopic(toRobotPrefix + queueSpecTopicName, "string");
+  ntClient.publishTopic(toRobotPrefix + queueCommandTopicName, "string");
   ntClient.connect();
 });
 
 // ***** STATE CACHE *****
 
-let selectedLevel = 0; // 0 = L2, 1 = L3, 2 = L4
+let selectedLevel = 2; // 0 = L2, 1 = L3, 2 = L4 (default to L4)
 let l1State = 0; // Count
 let l2State = 0; // Bitfield
 let l3State = 0; // Bitfield
@@ -99,13 +109,36 @@ let l4State = 0; // Bitfield
 let algaeState = 0; // Bitfield
 let coopState = false; // Boolean
 let isElims = false; // Boolean
+let queueState = { steps: [], manual: false };
+const queueDragState = { active: false, fromIndex: null };
+
+function isFiniteNumber(value) {
+  if (typeof Number.isFinite === "function") {
+    return Number.isFinite(value);
+  }
+  return isFinite(value);
+}
+
+function clampSelectedLevel(value) {
+  const numeric = typeof value === "number" ? value : Number(value);
+  if (!isFiniteNumber(numeric)) {
+    return 2;
+  }
+  return Math.max(0, Math.min(2, Math.floor(numeric)));
+}
+
+function getSelectedLevelIndex() {
+  return clampSelectedLevel(selectedLevel);
+}
 
 /** Update the full UI based on the state cache. */
 function updateUI() {
+  const levelIndex = getSelectedLevelIndex();
+
   // Update counter highlight
   Array.from(document.getElementsByClassName("counter-area")).forEach(
     (element, index) => {
-      if (index > 0 && selectedLevel === index - 1) {
+      if (index > 0 && levelIndex === index - 1) {
         element.classList.add("active");
       } else {
         element.classList.remove("active");
@@ -114,7 +147,7 @@ function updateUI() {
   );
 
   // Update background color
-  switch (selectedLevel) {
+  switch (levelIndex) {
     case 0:
       document.body.style.backgroundColor = "#5AB7ED";
       break;
@@ -150,7 +183,7 @@ function updateUI() {
   // Update coral buttons
   Array.from(document.getElementsByClassName("branch")).forEach(
     (element, index) => {
-      let levelState = [l2State, l3State, l4State][selectedLevel];
+      let levelState = [l2State, l3State, l4State][levelIndex];
       if (((1 << index) & levelState) > 0) {
         element.classList.add("active");
       } else {
@@ -190,6 +223,285 @@ function updateUI() {
   }
 }
 
+// ***** QUEUE MANAGEMENT *****
+
+function applyQueueState(raw) {
+  try {
+    const payload = JSON.parse(raw);
+    if (!payload || typeof payload !== "object") {
+      return;
+    }
+    queueState = payload;
+    renderQueue();
+  } catch (error) {
+    console.error("Failed to parse queue state", error);
+  }
+}
+
+function renderQueue() {
+  const list = document.getElementById("queue-plan");
+  if (!list) {
+    return;
+  }
+  list.innerHTML = "";
+
+  const steps = queueState && Array.isArray(queueState.steps) ? queueState.steps : [];
+  const manualEnabled = !!(queueState && queueState.manual);
+  if (steps.length === 0) {
+    const placeholder = document.createElement("li");
+    placeholder.className = "queue-placeholder";
+    placeholder.innerText = "No steps queued.";
+    list.appendChild(placeholder);
+  } else {
+    steps.forEach((step, index) => {
+      const status = (step.status ? step.status : "PENDING").toUpperCase();
+      const li = document.createElement("li");
+      li.className = `queue-item status-${status.toLowerCase()}`;
+      li.setAttribute("data-queue-index", String(index));
+       li.setAttribute("draggable", "true");
+      li.innerHTML = `
+        <div>
+          <div class="queue-item-title">${formatStepTitle(step)}</div>
+          <div class="queue-item-meta">${formatStepMeta(step)}</div>
+        </div>
+        <div class="queue-item-actions">
+          <span class="queue-status-badge">${statusLabel(status)}</span>
+        </div>
+      `;
+      list.appendChild(li);
+    });
+  }
+
+  const phaseEl = document.getElementById("queue-phase");
+  if (phaseEl) {
+    phaseEl.innerText = queueState && queueState.phase ? queueState.phase : "IDLE";
+  }
+
+  const syncEl = document.getElementById("queue-sync-indicator");
+  if (syncEl) {
+    const running = queueState && queueState.running;
+    syncEl.hidden = !!running;
+    syncEl.innerText = running ? "" : manualEnabled ? "Manual" : "Idle";
+  }
+
+  const messageEl = document.getElementById("queue-message");
+  if (messageEl) {
+    const base = queueState && queueState.message ? queueState.message : "Waiting for queue...";
+    messageEl.innerText = base;
+  }
+
+  const activeEl = document.getElementById("queue-active-step");
+  if (activeEl) {
+    const active =
+      queueState && queueState.activeStep
+        ? queueState.activeStep
+        : manualEnabled
+          ? "Manual Control"
+          : "--";
+    activeEl.innerText = `Active Step: ${active}`;
+  }
+
+  const manualToggle = document.getElementById("queue-manual-toggle");
+  if (manualToggle) {
+    manualToggle.innerText = manualEnabled ? "Enable Queue" : "Disable Queue";
+    manualToggle.classList.toggle("queue-control-active", manualEnabled);
+    manualToggle.setAttribute("aria-pressed", manualEnabled ? "true" : "false");
+  }
+
+  const startButton = document.querySelector('[data-queue-command="start"]');
+  if (startButton) {
+    startButton.disabled = manualEnabled;
+    startButton.title = manualEnabled ? "Disable manual mode to run the queue." : "";
+  }
+}
+
+function formatStepTitle(step) {
+  if (step.type === "REEF") {
+    const face = step.face != null ? step.face : 1;
+    const sideToken = (step.side ? step.side : "LEFT").toLowerCase();
+    const prettySide = sideToken.charAt(0).toUpperCase() + sideToken.slice(1);
+    return `Reef - Face ${face} (${prettySide})`;
+  }
+  const source = (step.source ? step.source : "NEAREST").toLowerCase();
+  const prettySource = source.charAt(0).toUpperCase() + source.slice(1);
+  return `Source - ${prettySource}`;
+}
+
+function formatStepMeta(step) {
+  if (step.type === "REEF") {
+    return `Level ${step.level ? step.level : "L3"}`;
+  }
+  return "Align to station";
+}
+
+function statusLabel(status) {
+  return status.replace(/_/g, " ");
+}
+
+function sendQueueCommand(command, extras) {
+  if (!command) {
+    return;
+  }
+  const payload = Object.assign(
+    { command: command.toUpperCase(), at: Date.now() },
+    extras || {}
+  );
+  ntClient.addSample(toRobotPrefix + queueCommandTopicName, JSON.stringify(payload));
+}
+
+function sendAddStep(step) {
+  if (!step || !step.type) {
+    return;
+  }
+  sendQueueCommand("ADD", { step });
+}
+
+function addReefStepFromBranch(index) {
+  const face = Math.floor(index / 2) + 1;
+  const side = index % 2 === 0 ? "LEFT" : "RIGHT";
+  const levelTokens = ["L2", "L3", "L4"];
+  const levelIndex = getSelectedLevelIndex();
+  const level = levelTokens[levelIndex] || "L3";
+  sendAddStep({ type: "SOURCE", source: side });
+  sendAddStep({ type: "REEF", face, side, level });
+}
+
+function initQueueUi() {
+  const queueList = document.getElementById("queue-plan");
+  if (queueList) {
+    queueList.addEventListener("click", (event) => {
+      if (queueDragState.active) {
+        return;
+      }
+      const item = findQueueItemElement(event.target, queueList);
+      if (!item) {
+        return;
+      }
+      const index = Number(item.getAttribute("data-queue-index"));
+      if (!isNaN(index)) {
+        sendQueueCommand("REMOVE", { index });
+      }
+    });
+    enableQueueReordering(queueList);
+  }
+
+  document
+    .querySelectorAll("[data-queue-command]")
+    .forEach((button) =>
+      button.addEventListener("click", () => sendQueueCommand(button.dataset.queueCommand))
+    );
+
+  const manualToggle = document.getElementById("queue-manual-toggle");
+  if (manualToggle) {
+    manualToggle.addEventListener("click", () => {
+      const manualEnabled = !!(queueState && queueState.manual);
+      sendQueueCommand("MANUAL", { manual: !manualEnabled });
+    });
+  }
+
+  renderQueue();
+}
+
+function findQueueItemElement(element, container) {
+  let node = element;
+  while (node && node !== container) {
+    if (node.hasAttribute && node.hasAttribute("data-queue-index")) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}
+
+function enableQueueReordering(queueList) {
+  queueList.addEventListener("dragstart", (event) => {
+    const item = findQueueItemElement(event.target, queueList);
+    if (!item) {
+      return;
+    }
+    const index = Number(item.getAttribute("data-queue-index"));
+    if (isNaN(index)) {
+      return;
+    }
+    queueDragState.active = true;
+    queueDragState.fromIndex = index;
+    item.classList.add("dragging");
+    queueList.classList.add("queue-dragging");
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("text/plain", String(index));
+    }
+  });
+
+  queueList.addEventListener("dragover", (event) => {
+    if (!queueDragState.active) {
+      return;
+    }
+    event.preventDefault();
+  });
+
+  queueList.addEventListener("drop", (event) => {
+    if (!queueDragState.active) {
+      return;
+    }
+    event.preventDefault();
+    const dropIndex = computeDropIndex(event, queueList);
+    handleQueueReorder(dropIndex);
+    finishQueueDrag(queueList);
+  });
+
+  queueList.addEventListener("dragend", () => {
+    finishQueueDrag(queueList);
+  });
+}
+
+function computeDropIndex(event, queueList) {
+  const items = Array.from(queueList.querySelectorAll(".queue-item"));
+  if (items.length === 0) {
+    return 0;
+  }
+  const pointerY = typeof event.clientY === "number" ? event.clientY : 0;
+  for (const item of items) {
+    const rect = item.getBoundingClientRect();
+    if (pointerY < rect.top + rect.height / 2) {
+      const index = Number(item.getAttribute("data-queue-index"));
+      return isNaN(index) ? 0 : index;
+    }
+  }
+  return items.length;
+}
+
+function handleQueueReorder(dropIndex) {
+  if (queueDragState.fromIndex == null || dropIndex == null) {
+    return;
+  }
+  const steps = queueState && Array.isArray(queueState.steps) ? queueState.steps : [];
+  if (steps.length < 2) {
+    return;
+  }
+  const fromIndex = queueDragState.fromIndex;
+  let toIndex = Math.max(0, Math.min(dropIndex, steps.length));
+  if (fromIndex < toIndex) {
+    toIndex -= 1;
+  }
+  if (fromIndex === toIndex) {
+    return;
+  }
+  sendQueueCommand("MOVE", { fromIndex, toIndex });
+}
+
+function finishQueueDrag(queueList) {
+  queueDragState.active = false;
+  queueDragState.fromIndex = null;
+  if (!queueList) {
+    return;
+  }
+  queueList.classList.remove("queue-dragging");
+  queueList
+    .querySelectorAll(".queue-item.dragging")
+    .forEach((node) => node.classList.remove("dragging"));
+}
+
 // ***** BUTTON BINDINGS *****
 
 let isTouch = false;
@@ -227,7 +539,10 @@ window.addEventListener("load", () => {
     (element, index) => {
       if (index > 0) {
         bind(element, () => {
-          ntClient.addSample(toRobotPrefix + selectedLevelTopicName, index - 1);
+          const newLevel = clampSelectedLevel(index - 1);
+          ntClient.addSample(toRobotPrefix + selectedLevelTopicName, newLevel);
+          selectedLevel = newLevel;
+          updateUI();
         });
       }
     }
@@ -237,25 +552,35 @@ window.addEventListener("load", () => {
   Array.from(document.getElementsByClassName("branch")).forEach(
     (element, index) => {
       bind(element, () => {
-        switch (selectedLevel) {
+        const bit = 1 << index;
+        let currentState = 0;
+        let topic = l2TopicName;
+        const levelIndex = getSelectedLevelIndex();
+        switch (levelIndex) {
           case 0:
-            ntClient.addSample(
-              toRobotPrefix + l2TopicName,
-              l2State ^ (1 << index)
-            );
+            currentState = l2State;
+            topic = l2TopicName;
             break;
           case 1:
-            ntClient.addSample(
-              toRobotPrefix + l3TopicName,
-              l3State ^ (1 << index)
-            );
+            currentState = l3State;
+            topic = l3TopicName;
             break;
           case 2:
-            ntClient.addSample(
-              toRobotPrefix + l4TopicName,
-              l4State ^ (1 << index)
-            );
+            currentState = l4State;
+            topic = l4TopicName;
             break;
+        }
+        const newState = currentState ^ bit;
+        ntClient.addSample(toRobotPrefix + topic, newState);
+        if (levelIndex === 0) {
+          l2State = newState;
+        } else if (levelIndex === 1) {
+          l3State = newState;
+        } else {
+          l4State = newState;
+        }
+        if ((newState & bit) > 0) {
+          addReefStepFromBranch(index);
         }
       });
     }
@@ -287,6 +612,9 @@ window.addEventListener("load", () => {
   bind(document.getElementsByClassName("coop")[0], () => {
     ntClient.addSample(toRobotPrefix + coopTopicName, !coopState);
   });
+
+  initQueueUi();
+  updateUI();
 });
 
 // ***** REEF CANVAS *****

--- a/src/main/java/frc/robot/Config.java
+++ b/src/main/java/frc/robot/Config.java
@@ -17,7 +17,7 @@ public final class Config {
     public static final boolean AUTONOMOUS_ENABLED = true;
     public static final boolean VISION_ENABLED = false;
     public static final boolean LEDS_ENABLED = false;
-    public static final boolean WEBUI_ENABLED = false;
+    public static final boolean WEBUI_ENABLED = true;
     public static final boolean IsSwerveSpark = false;
   }
 
@@ -26,38 +26,8 @@ public final class Config {
     private static final int DEFAULT_PORT = 5805;
 
     public static final boolean ENABLED = Subsystems.WEBUI_ENABLED;
-    public static final String BIND_ADDRESS =
-        getStringConfig("webui.bindAddress", "WEBUI_BIND_ADDRESS", DEFAULT_BIND_ADDRESS);
-    public static final int PORT = getIntConfig("webui.port", "WEBUI_PORT", DEFAULT_PORT);
-
-    private static String getStringConfig(String propertyKey, String envKey, String fallback) {
-      String property = System.getProperty(propertyKey);
-      if (property != null && !property.isBlank()) {
-        return property;
-      }
-      String env = System.getenv(envKey);
-      if (env != null && !env.isBlank()) {
-        return env;
-      }
-      return fallback;
-    }
-
-    private static int getIntConfig(String propertyKey, String envKey, int fallback) {
-      String raw = System.getProperty(propertyKey);
-      if (raw == null || raw.isBlank()) {
-        raw = System.getenv(envKey);
-      }
-      if (raw == null || raw.isBlank()) {
-        return fallback;
-      }
-      try {
-        return Integer.parseInt(raw.trim());
-      } catch (NumberFormatException ex) {
-        System.err.println(
-            "Invalid WebUI port '" + raw + "', falling back to default " + fallback + ".");
-        return fallback;
-      }
-    }
+    public static final String BIND_ADDRESS = DEFAULT_BIND_ADDRESS;
+    public static final int PORT = DEFAULT_PORT;
   }
 
   public static final class Controllers {

--- a/src/main/java/frc/robot/GlobalConstants.java
+++ b/src/main/java/frc/robot/GlobalConstants.java
@@ -37,7 +37,7 @@ import lombok.Getter;
  */
 public final class GlobalConstants {
   public static final RobotMode MODE = RobotMode.REAL;
-  public static final RobotType ROBOT = RobotType.CRESCENDO;
+  public static final RobotType ROBOT = RobotType.COMPBOT;
   public static final double ODOMETRY_FREQUENCY = 250.0;
 
   public static boolean TUNING_MODE = false;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -93,8 +93,7 @@ public class RobotContainer {
   private final Superstructure superstructure = new Superstructure(null);
   private final Vision vision;
 
-  private TabletInterfaceTracker tabletInterfaceTracker;
-  // private final TabletInterfaceTracker tabletInterfaceTracker;
+  private final TabletInterfaceTracker tabletInterfaceTracker;
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
@@ -146,10 +145,6 @@ public class RobotContainer {
                   new ModuleIO() {});
           };
 
-      if (WEBUI_ENABLED)
-        tabletInterfaceTracker = new TabletInterfaceTracker(new ReefControlsIOServer());
-      else tabletInterfaceTracker = null;
-
       autoIdleCommand = Commands.none();
       if (AUTONOMOUS_ENABLED) {
         autoChooser = new LoggedDashboardChooser<>("Auto Choices", AutoBuilder.buildAutoChooser());
@@ -162,6 +157,13 @@ public class RobotContainer {
     } else {
       drive = null;
     }
+
+    if (WEBUI_ENABLED) {
+      tabletInterfaceTracker = new TabletInterfaceTracker(new ReefControlsIOServer(), drive);
+    } else {
+      tabletInterfaceTracker = null;
+    }
+
     if (AUTONOMOUS_ENABLED) {
       if (drive != null) {
         AutoCommands.registerAutoCommands(superstructure, drive);
@@ -221,6 +223,20 @@ public class RobotContainer {
       characterizationChooser.addOption(
           "Drive | SysId (Dynamic Reverse)",
           drive.sysIdDynamic(SysIdRoutine.Direction.kReverse).ignoringDisable(true));
+      characterizationChooser.addOption(
+          "Turn | SysId (Full Routine)", drive.sysIdTurnRoutine().ignoringDisable(true));
+      characterizationChooser.addOption(
+          "Turn | SysId (Quasistatic Forward)",
+          drive.sysIdTurnQuasistatic(SysIdRoutine.Direction.kForward).ignoringDisable(true));
+      characterizationChooser.addOption(
+          "Turn | SysId (Quasistatic Reverse)",
+          drive.sysIdTurnQuasistatic(SysIdRoutine.Direction.kReverse).ignoringDisable(true));
+      characterizationChooser.addOption(
+          "Turn | SysId (Dynamic Forward)",
+          drive.sysIdTurnDynamic(SysIdRoutine.Direction.kForward).ignoringDisable(true));
+      characterizationChooser.addOption(
+          "Turn | SysId (Dynamic Reverse)",
+          drive.sysIdTurnDynamic(SysIdRoutine.Direction.kReverse).ignoringDisable(true));
     }
 
     superstructure.registerSuperstructureCharacterization(() -> characterizationChooser);

--- a/src/main/java/frc/robot/commands/DriveCommands.java
+++ b/src/main/java/frc/robot/commands/DriveCommands.java
@@ -557,6 +557,35 @@ public class DriveCommands {
         Set.of(drive));
   }
 
+  public static Command alignToCoralStationCommandAuto(SwerveSubsystem drive, boolean leftStation) {
+    return Commands.defer(
+        () -> {
+          Supplier<Pose2d> target =
+              () -> {
+                Pose2d base =
+                    leftStation
+                        ? Coordinates.LEFT_CORAL_STATION.getPose()
+                        : Coordinates.RIGHT_CORAL_STATION.getPose();
+                Transform2d bumper =
+                    new Transform2d(
+                        new Translation2d(0, GlobalConstants.AlignOffsets.BUMPER_TO_CENTER_OFFSET)
+                            .rotateBy(base.getRotation()),
+                        new Rotation2d());
+                double sideSign = leftStation ? -1.0 : 1.0;
+                Transform2d sideToSide =
+                    new Transform2d(
+                        new Translation2d(
+                                GlobalConstants.AlignOffsets.SIDE_TO_SIDE_OFFSET_AUTO * sideSign, 0)
+                            .rotateBy(base.getRotation()),
+                        new Rotation2d());
+                return base.plus(bumper).plus(sideToSide);
+              };
+
+          return holonomicAlignCommand(drive, target, () -> 0.0, false, true);
+        },
+        Set.of(drive));
+  }
+
   /** helper methods for alignment */
 
   // returns the coordinates of the nearest coral station

--- a/src/main/java/frc/robot/subsystems/objectivetracker/ReefControlsIO.java
+++ b/src/main/java/frc/robot/subsystems/objectivetracker/ReefControlsIO.java
@@ -19,6 +19,8 @@ public interface ReefControlsIO {
     public int[] level4State = new int[] {}; // Bitfield
     public int[] algaeState = new int[] {}; // Bitfield
     public boolean[] coopState = new boolean[] {}; // Boolean
+    public String[] queueSpec = new String[] {}; // JSON payload from dashboard
+    public String[] queueCommand = new String[] {}; // JSON command payload from dashboard
   }
 
   default void updateInputs(ReefControlsIOInputs inputs) {}
@@ -38,4 +40,6 @@ public interface ReefControlsIO {
   default void setCoopState(boolean value) {}
 
   default void setElims(boolean isElims) {}
+
+  default void setQueueState(String stateJson) {}
 }

--- a/src/main/java/frc/robot/subsystems/objectivetracker/TabletInterfaceTracker.java
+++ b/src/main/java/frc/robot/subsystems/objectivetracker/TabletInterfaceTracker.java
@@ -1,36 +1,107 @@
 package frc.robot.subsystems.objectivetracker;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Filesystem;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Config;
+import frc.robot.commands.DriveCommands;
+import frc.robot.subsystems.swerve.SwerveSubsystem;
+import frc.robot.util.NamedTargets;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.littletonrobotics.junction.Logger;
 
-public class TabletInterfaceTracker extends SubsystemBase {
+public class TabletInterfaceTracker extends SubsystemBase implements AutoCloseable {
+  private static final ObjectMapper JSON =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   private final ReefControlsIO io;
   private final ReefControlsIOInputsAutoLogged inputs = new ReefControlsIOInputsAutoLogged();
+  private final SwerveSubsystem drive;
+  private final TabletWebServer webServer;
 
-  private boolean buttonClicked = false;
-  private int selectedLevel = 0;
+  // Legacy reef controls state mirrored back to the web UI
+  private int selectedLevel = 2;
   private int level1Coral = 0;
   private int level2Coral = 0;
   private int level3Coral = 0;
   private int level4Coral = 0;
   private int algae = 0;
+  private boolean coop = false;
+
+  // Queue + autonomy state
+  private final List<QueueStep> queueSteps = new ArrayList<>();
+  private int queueRevision = 0;
+  private boolean queueRunning = false;
+  private boolean manualOverride = false;
+  private QueuePhase phase = QueuePhase.IDLE;
+  private Command activeCommand;
+  private String activeLabel = "";
+  private String queueMessage = "Tap a reef node to build the queue.";
+  private String lastQueueStateJson = "";
+  private ApproachSide preferredSourceSide = ApproachSide.LEFT;
 
   public TabletInterfaceTracker(ReefControlsIO io) {
-    this.io = io;
+    this(io, null);
+  }
+
+  public TabletInterfaceTracker(ReefControlsIO io, SwerveSubsystem drive) {
+    this.io = Objects.requireNonNull(io, "io");
+    this.drive = drive;
+    this.webServer = maybeStartWebServer();
+  }
+
+  private TabletWebServer maybeStartWebServer() {
+    if (!Config.WebUIConfig.ENABLED) {
+      return null;
+    }
+    try {
+      TabletWebServer server =
+          new TabletWebServer(
+              Filesystem.getDeployDirectory().toPath().resolve("reefcontrols"),
+              Config.WebUIConfig.BIND_ADDRESS,
+              Config.WebUIConfig.PORT);
+      server.start();
+      return server;
+    } catch (IOException ex) {
+      DriverStation.reportError("Failed to start tablet web server", ex.getStackTrace());
+      return null;
+    }
   }
 
   @Override
   public void periodic() {
     io.updateInputs(inputs);
-    // Logger.processInputs("ReefControls", inputs);
+    Logger.processInputs("ReefControls", inputs);
 
-    /*if (inputs.algaeState.length > 0) {
-      buttonClicked = inputs.algaeState[0] > 0;
-    }*/
-    updateTablet();
+    updateReefControlsMirror();
+    handleQueueInputs();
+    updateQueueExecution();
+    publishQueueState();
+    logQueueState();
   }
 
-  private void updateTablet() {
+  private void updateReefControlsMirror() {
     if (inputs.selectedLevel.length > 0) {
       selectedLevel = inputs.selectedLevel[0];
     }
@@ -46,20 +117,697 @@ public class TabletInterfaceTracker extends SubsystemBase {
     if (inputs.level4State.length > 0) {
       level4Coral = inputs.level4State[0];
     }
+    if (inputs.algaeState.length > 0) {
+      algae = inputs.algaeState[0];
+    }
+    if (inputs.coopState.length > 0) {
+      coop = inputs.coopState[0];
+    }
 
     io.setSelectedLevel(selectedLevel);
     io.setLevel1State(level1Coral);
     io.setLevel2State(level2Coral);
     io.setLevel3State(level3Coral);
     io.setLevel4State(level4Coral);
-
-    if (inputs.algaeState.length > 0) {
-      algae = inputs.algaeState[0];
-    }
-
     io.setAlgaeState(algae);
+    io.setCoopState(coop);
   }
 
-  // public boolean buttonClicked() {return buttonClicked}
+  private void handleQueueInputs() {
+    if (inputs.queueSpec.length > 0) {
+      applyQueueSpec(inputs.queueSpec[0]);
+    }
+    if (inputs.queueCommand.length > 0) {
+      applyQueueCommand(inputs.queueCommand[0]);
+    }
+  }
 
+  private void applyQueueSpec(String raw) {
+    if (raw == null || raw.isBlank()) {
+      clearQueue("Queue cleared.");
+      return;
+    }
+    try {
+      QueueSpecPayload payload = JSON.readValue(raw, QueueSpecPayload.class);
+      int revision = payload.revision() == null ? queueRevision : payload.revision();
+      List<QueueStep> parsed = new ArrayList<>();
+      if (payload.steps() != null) {
+        for (QueueStepDto dto : payload.steps()) {
+          if (dto == null) {
+            continue;
+          }
+          QueueStep.fromDto(dto).ifPresent(parsed::add);
+        }
+      }
+      queueSteps.clear();
+      queueSteps.addAll(parsed);
+      updatePreferredSourceSideFromQueue();
+      queueRevision = revision;
+      cancelActiveCommand();
+      queueRunning = false;
+      phase = QueuePhase.IDLE;
+      activeLabel = "";
+      queueMessage = queueSteps.isEmpty() ? "Queue cleared." : "Queue updated. Press Start to run.";
+    } catch (Exception ex) {
+      DriverStation.reportError(
+          "Tablet queue spec parse failed: " + ex.getMessage(), ex.getStackTrace());
+    }
+  }
+
+  private void applyQueueCommand(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return;
+    }
+    try {
+      QueueCommandPayload payload = JSON.readValue(raw, QueueCommandPayload.class);
+      QueueCommand command = QueueCommand.from(payload.command());
+      if (command == null) {
+        return;
+      }
+      switch (command) {
+        case START -> startQueue();
+        case STOP -> stopQueue("Queue paused.");
+        case SKIP -> skipStep();
+        case RESET -> clearQueue("Queue reset.");
+        case ADD -> enqueueStep(payload.step());
+        case REMOVE -> removeStep(payload.index());
+        case MOVE -> moveStep(payload.fromIndex(), payload.toIndex());
+        case MANUAL -> setManualOverride(payload.manual());
+      }
+    } catch (Exception ex) {
+      DriverStation.reportError(
+          "Tablet queue command parse failed: " + ex.getMessage(), ex.getStackTrace());
+    }
+  }
+
+  private void startQueue() {
+    if (manualOverride) {
+      queueMessage = "Manual override enabled. Disable it to run the queue.";
+      queueRunning = false;
+      phase = QueuePhase.MANUAL;
+      return;
+    }
+    if (queueSteps.isEmpty()) {
+      queueMessage = "Queue is empty. Tap a reef to add one.";
+      queueRunning = false;
+      phase = QueuePhase.IDLE;
+      return;
+    }
+    queueRunning = true;
+    phase = QueuePhase.RUNNING;
+    queueMessage = "Executing queue.";
+    if (activeCommand == null) {
+      startNextStep();
+    }
+  }
+
+  private void stopQueue(String message) {
+    queueRunning = false;
+    phase = manualOverride ? QueuePhase.MANUAL : QueuePhase.IDLE;
+    queueMessage = message;
+    cancelActiveCommand();
+  }
+
+  private void skipStep() {
+    if (queueSteps.isEmpty()) {
+      queueMessage = "Nothing to skip.";
+      return;
+    }
+    removeStepInternal(0, true);
+  }
+
+  private void clearQueue(String message) {
+    queueSteps.clear();
+    queueRevision++;
+    cancelActiveCommand();
+    queueRunning = false;
+    phase = manualOverride ? QueuePhase.MANUAL : QueuePhase.IDLE;
+    activeLabel = "";
+    preferredSourceSide = ApproachSide.LEFT;
+    queueMessage = message;
+  }
+
+  private void enqueueStep(QueueStepDto dto) {
+    if (dto == null) {
+      queueMessage = "Ignored empty queue step.";
+      return;
+    }
+    QueueStep.fromDto(dto)
+        .ifPresent(
+            step -> {
+              queueSteps.add(step);
+              queueRevision++;
+              if (step.type == StepType.REEF && step.side != null) {
+                preferredSourceSide = step.side;
+              }
+              queueMessage = "Queued " + step.label() + ".";
+              if (queueRunning && activeCommand == null) {
+                startNextStep();
+              }
+            });
+  }
+
+  private void removeStep(Integer indexValue) {
+    if (indexValue == null) {
+      queueMessage = "No step selected.";
+      return;
+    }
+    removeStepInternal(indexValue.intValue(), false);
+  }
+
+  private void removeStepInternal(int index, boolean fromSkip) {
+    if (index < 0 || index >= queueSteps.size()) {
+      queueMessage = "No step found.";
+      return;
+    }
+    boolean wasRunning = queueRunning;
+    boolean removingActive = wasRunning && index == 0;
+    QueueStep removed = queueSteps.remove(index);
+    queueRevision++;
+    if (removingActive) {
+      cancelActiveCommand();
+    }
+
+    if (queueSteps.isEmpty()) {
+      queueRunning = false;
+      phase = manualOverride ? QueuePhase.MANUAL : QueuePhase.IDLE;
+      activeLabel = "";
+      queueMessage = fromSkip ? "Skipped last task." : "Removed " + removed.label() + ".";
+      preferredSourceSide = ApproachSide.LEFT;
+      return;
+    }
+
+    if (removingActive && wasRunning) {
+      queueMessage = fromSkip ? "Skipped to next task." : "Removed active task.";
+      if (queueRunning) {
+        startNextStep();
+      }
+    } else {
+      queueMessage = fromSkip ? "Skipped task." : "Removed " + removed.label() + ".";
+    }
+    updatePreferredSourceSideFromQueue();
+  }
+
+  private void moveStep(Integer fromIndexValue, Integer toIndexValue) {
+    if (fromIndexValue == null || toIndexValue == null) {
+      queueMessage = "Move request missing index.";
+      return;
+    }
+    if (queueSteps.size() < 2) {
+      queueMessage = "Not enough steps to reorder.";
+      return;
+    }
+    int size = queueSteps.size();
+    int from = Math.max(0, Math.min(size - 1, fromIndexValue.intValue()));
+    int to = Math.max(0, Math.min(size, toIndexValue.intValue()));
+    if (from == to) {
+      queueMessage = "Step already in that position.";
+      return;
+    }
+    QueueStep moved = queueSteps.remove(from);
+    if (to > queueSteps.size()) {
+      to = queueSteps.size();
+    }
+    queueSteps.add(to, moved);
+    queueRevision++;
+    updatePreferredSourceSideFromQueue();
+    boolean movedHead = from == 0 || to == 0;
+    if (movedHead) {
+      cancelActiveCommand();
+      activeLabel = "";
+      if (queueRunning) {
+        startNextStep();
+      } else {
+        queueMessage = "Queue reordered.";
+      }
+    } else {
+      queueMessage = "Moved " + moved.label() + ".";
+    }
+  }
+
+  private void setManualOverride(Boolean manualValue) {
+    if (manualValue == null) {
+      queueMessage =
+          manualOverride ? "Manual override already enabled." : "Manual override already disabled.";
+      return;
+    }
+    boolean enable = manualValue.booleanValue();
+    if (enable == manualOverride) {
+      queueMessage =
+          enable ? "Manual override already enabled." : "Manual override already disabled.";
+      return;
+    }
+    manualOverride = enable;
+    if (manualOverride) {
+      stopQueue("Manual override enabled. Queue paused.");
+      activeLabel = "";
+    } else {
+      if (!queueRunning) {
+        phase = queueSteps.isEmpty() ? QueuePhase.IDLE : QueuePhase.IDLE;
+      }
+      queueMessage = "Manual override disabled. Queue ready.";
+    }
+  }
+
+  private void updatePreferredSourceSideFromQueue() {
+    preferredSourceSide =
+        queueSteps.stream()
+            .filter(step -> step.type == StepType.REEF && step.side != null)
+            .map(step -> step.side)
+            .findFirst()
+            .orElse(ApproachSide.LEFT);
+  }
+
+  private void updateQueueExecution() {
+    if (queueRunning && drive == null) {
+      DriverStation.reportWarning("Tablet queue cannot run without a drive subsystem", false);
+      stopQueue("Drive not available.");
+      return;
+    }
+
+    if (queueRunning && activeCommand == null) {
+      startNextStep();
+    }
+
+    if (activeCommand != null && !CommandScheduler.getInstance().isScheduled(activeCommand)) {
+      activeCommand = null;
+      if (!queueSteps.isEmpty()) {
+        queueSteps.remove(0);
+        queueRevision++;
+      }
+      if (queueSteps.isEmpty()) {
+        finishQueue();
+      } else if (queueRunning) {
+        startNextStep();
+      }
+    }
+  }
+
+  private void startNextStep() {
+    if (!queueRunning || queueSteps.isEmpty()) {
+      finishQueue();
+      return;
+    }
+    QueueStep step = queueSteps.get(0);
+    if (step.type == StepType.REEF && step.side != null) {
+      preferredSourceSide = step.side;
+    }
+    Command command = buildCommand(step);
+    if (command == null) {
+      queueMessage = "Failed to build command for " + step.label() + ".";
+      queueSteps.remove(0);
+      queueRevision++;
+      if (queueSteps.isEmpty()) {
+        finishQueue();
+      } else {
+        startNextStep();
+      }
+      return;
+    }
+    cancelActiveCommand();
+    activeCommand = command;
+    CommandScheduler.getInstance().schedule(command);
+    activeLabel = step.label();
+    queueMessage = "Aligning to " + activeLabel;
+    phase = QueuePhase.RUNNING;
+  }
+
+  private void finishQueue() {
+    cancelActiveCommand();
+    queueRunning = false;
+    if (queueSteps.isEmpty()) {
+      phase = manualOverride ? QueuePhase.MANUAL : QueuePhase.COMPLETE;
+      queueMessage = "Queue finished.";
+      preferredSourceSide = ApproachSide.LEFT;
+      activeLabel = "";
+    } else {
+      phase = manualOverride ? QueuePhase.MANUAL : QueuePhase.IDLE;
+    }
+  }
+
+  private void cancelActiveCommand() {
+    if (activeCommand != null) {
+      if (CommandScheduler.getInstance().isScheduled(activeCommand)) {
+        activeCommand.cancel();
+      }
+      activeCommand = null;
+    }
+  }
+
+  private Command buildCommand(QueueStep step) {
+    if (drive == null) {
+      return null;
+    }
+    return switch (step.type) {
+      case SOURCE -> {
+        SourcePreference preference = step.source == null ? SourcePreference.NEAREST : step.source;
+        if (preference == SourcePreference.NEAREST && preferredSourceSide != null) {
+          preference =
+              preferredSourceSide == ApproachSide.LEFT
+                  ? SourcePreference.LEFT
+                  : SourcePreference.RIGHT;
+        }
+        yield switch (preference) {
+          case LEFT -> DriveCommands.alignToCoralStationCommandAuto(drive, true);
+          case RIGHT -> DriveCommands.alignToCoralStationCommandAuto(drive, false);
+          case NEAREST -> DriveCommands.alignToNearestCoralStationCommandAuto(drive);
+        };
+      }
+      case REEF -> {
+        String target = step.targetName();
+        yield NamedTargets.goTo(drive, target);
+      }
+    };
+  }
+
+  private void publishQueueState() {
+    String json = buildQueueStateJson();
+    if (!json.equals(lastQueueStateJson)) {
+      io.setQueueState(json);
+      lastQueueStateJson = json;
+    }
+  }
+
+  private String buildQueueStateJson() {
+    try {
+      List<QueueStateStep> steps = new ArrayList<>();
+      for (int i = 0; i < queueSteps.size(); i++) {
+        QueueStep step = queueSteps.get(i);
+        StepStatus status = statusForIndex(i);
+        steps.add(
+            new QueueStateStep(
+                step.type.name(),
+                step.source == null ? null : step.source.name(),
+                step.type == StepType.REEF ? step.face : null,
+                step.type == StepType.REEF && step.side != null ? step.side.name() : null,
+                step.type == StepType.REEF && step.level != null ? step.level.name() : null,
+                step.label(),
+                status.name()));
+      }
+      int activeIndex = queueRunning && !queueSteps.isEmpty() ? 0 : -1;
+      QueueStatePayload payload =
+          new QueueStatePayload(
+              queueRevision,
+              queueRunning,
+              manualOverride,
+              phase.name(),
+              activeIndex,
+              queueMessage,
+              activeLabel,
+              steps);
+      return JSON.writeValueAsString(payload);
+    } catch (JsonProcessingException ex) {
+      DriverStation.reportError("Failed to serialize queue state", ex.getStackTrace());
+      return "{}";
+    }
+  }
+
+  private StepStatus statusForIndex(int index) {
+    if (index < 0 || index >= queueSteps.size()) {
+      return StepStatus.PENDING;
+    }
+    if (!queueRunning) {
+      return StepStatus.PENDING;
+    }
+    if (index == 0) {
+      return activeCommand != null ? StepStatus.ACTIVE : StepStatus.READY;
+    }
+    return StepStatus.QUEUED;
+  }
+
+  private void logQueueState() {
+    Logger.recordOutput("TabletQueue/Running", queueRunning);
+    Logger.recordOutput("TabletQueue/ManualOverride", manualOverride);
+    Logger.recordOutput("TabletQueue/Phase", phase.name());
+    Logger.recordOutput("TabletQueue/Length", queueSteps.size());
+    Logger.recordOutput("TabletQueue/ActiveTarget", activeLabel);
+  }
+
+  @Override
+  public void close() {
+    if (webServer != null) {
+      webServer.close();
+    }
+  }
+
+  private enum QueuePhase {
+    IDLE,
+    RUNNING,
+    COMPLETE,
+    MANUAL
+  }
+
+  private enum StepType {
+    SOURCE,
+    REEF
+  }
+
+  private enum StepStatus {
+    PENDING,
+    QUEUED,
+    READY,
+    ACTIVE
+  }
+
+  private enum SourcePreference {
+    LEFT,
+    RIGHT,
+    NEAREST;
+
+    private static SourcePreference parse(String value) {
+      if (value == null) {
+        return null;
+      }
+      try {
+        return SourcePreference.valueOf(value.trim().toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException ex) {
+        return null;
+      }
+    }
+  }
+
+  private enum ApproachSide {
+    LEFT,
+    RIGHT;
+
+    private static ApproachSide parse(String value) {
+      if (value == null) {
+        return null;
+      }
+      try {
+        return ApproachSide.valueOf(value.trim().toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException ex) {
+        return null;
+      }
+    }
+  }
+
+  private enum CoralLevel {
+    L1,
+    L2,
+    L3,
+    L4;
+
+    private static CoralLevel parse(String value) {
+      if (value == null) {
+        return CoralLevel.L3;
+      }
+      try {
+        return CoralLevel.valueOf(value.trim().toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException ex) {
+        return CoralLevel.L3;
+      }
+    }
+  }
+
+  private enum QueueCommand {
+    START,
+    STOP,
+    SKIP,
+    RESET,
+    ADD,
+    REMOVE,
+    MOVE,
+    MANUAL;
+
+    private static QueueCommand from(String value) {
+      if (value == null) {
+        return null;
+      }
+      try {
+        return QueueCommand.valueOf(value.trim().toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException ex) {
+        return null;
+      }
+    }
+  }
+
+  private static final class QueueStep {
+    private final StepType type;
+    private final SourcePreference source;
+    private final int face;
+    private final ApproachSide side;
+    private final CoralLevel level;
+
+    private QueueStep(QueueStepDto dto) {
+      Objects.requireNonNull(dto, "dto");
+      String typeValue = Objects.requireNonNull(dto.type(), "type");
+      this.type = StepType.valueOf(typeValue.trim().toUpperCase(Locale.ROOT));
+      if (type == StepType.SOURCE) {
+        this.source =
+            Optional.ofNullable(SourcePreference.parse(dto.source()))
+                .orElse(SourcePreference.NEAREST);
+        this.face = -1;
+        this.side = null;
+        this.level = null;
+      } else {
+        this.source = null;
+        this.face = dto.face() == null ? 1 : Math.max(1, Math.min(6, dto.face()));
+        this.side = Optional.ofNullable(ApproachSide.parse(dto.side())).orElse(ApproachSide.LEFT);
+        this.level = CoralLevel.parse(dto.level());
+      }
+    }
+
+    static Optional<QueueStep> fromDto(QueueStepDto dto) {
+      try {
+        return Optional.of(new QueueStep(dto));
+      } catch (Exception ex) {
+        DriverStation.reportWarning("Skipping invalid queue step: " + ex.getMessage(), false);
+        return Optional.empty();
+      }
+    }
+
+    private String label() {
+      return switch (type) {
+        case SOURCE -> "Source (" + source.name() + ")";
+        case REEF -> "Reef F"
+            + face
+            + " "
+            + (side == null ? "" : side.name())
+            + (level == null ? "" : " " + level.name());
+      };
+    }
+
+    private String targetName() {
+      if (type != StepType.REEF) {
+        return "";
+      }
+      String sideToken = side == ApproachSide.LEFT ? "L" : "R";
+      return "Reef_" + face + "_" + sideToken + "_Blue";
+    }
+  }
+
+  private record QueueSpecPayload(Integer revision, List<QueueStepDto> steps) {}
+
+  private record QueueStepDto(
+      String type, String source, Integer face, String side, String level) {}
+
+  private record QueueCommandPayload(
+      String command,
+      Long at,
+      QueueStepDto step,
+      Integer index,
+      Boolean manual,
+      Integer fromIndex,
+      Integer toIndex) {}
+
+  private record QueueStatePayload(
+      int revision,
+      boolean running,
+      boolean manual,
+      String phase,
+      int activeIndex,
+      String message,
+      String activeStep,
+      List<QueueStateStep> steps) {}
+
+  private record QueueStateStep(
+      String type,
+      String source,
+      Integer face,
+      String side,
+      String level,
+      String label,
+      String status) {}
+
+  private static final class TabletWebServer implements AutoCloseable {
+    private final Path webRoot;
+    private final HttpServer server;
+    private final ExecutorService executor;
+
+    TabletWebServer(Path webRoot, String bindAddress, int port) throws IOException {
+      this.webRoot = Objects.requireNonNull(webRoot, "webRoot").toAbsolutePath().normalize();
+      String bind = (bindAddress == null || bindAddress.isBlank()) ? "0.0.0.0" : bindAddress;
+      this.server = HttpServer.create(new InetSocketAddress(bind, port), 0);
+      this.executor =
+          Executors.newFixedThreadPool(
+              2,
+              r -> {
+                Thread t = new Thread(r);
+                t.setName("TabletWeb-" + t.getId());
+                t.setDaemon(true);
+                return t;
+              });
+      server.setExecutor(executor);
+      server.createContext("/", new StaticHandler());
+    }
+
+    void start() {
+      server.start();
+    }
+
+    @Override
+    public void close() {
+      server.stop(0);
+      executor.shutdownNow();
+    }
+
+    private Path resolveStaticPath(String requestPath) {
+      String normalized = requestPath;
+      if (normalized == null || normalized.isBlank() || "/".equals(normalized)) {
+        normalized = "/index.html";
+      }
+      Path resolved =
+          webRoot.resolve(normalized.replaceFirst("^/", "")).normalize().toAbsolutePath();
+      if (!resolved.startsWith(webRoot)) {
+        return webRoot.resolve("index.html");
+      }
+      return resolved;
+    }
+
+    private final class StaticHandler implements HttpHandler {
+      @Override
+      public void handle(HttpExchange exchange) throws IOException {
+        if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+          exchange.sendResponseHeaders(405, -1);
+          return;
+        }
+        URI uri = exchange.getRequestURI();
+        Path target = resolveStaticPath(uri.getPath());
+        if (!Files.exists(target) || Files.isDirectory(target)) {
+          target = webRoot.resolve("index.html");
+        }
+        byte[] bytes = Files.readAllBytes(target);
+        Headers headers = exchange.getResponseHeaders();
+        headers.add("Content-Type", inferredContentType(target));
+        headers.add("Cache-Control", "no-store");
+        exchange.sendResponseHeaders(200, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+          os.write(bytes);
+        }
+      }
+    }
+
+    private static String inferredContentType(Path file) {
+      String name = file.getFileName().toString().toLowerCase(Locale.ROOT);
+      if (name.endsWith(".html")) return "text/html; charset=utf-8";
+      if (name.endsWith(".css")) return "text/css; charset=utf-8";
+      if (name.endsWith(".js")) return "application/javascript; charset=utf-8";
+      if (name.endsWith(".json")) return "application/json; charset=utf-8";
+      if (name.endsWith(".png")) return "image/png";
+      if (name.endsWith(".jpg") || name.endsWith(".jpeg")) return "image/jpeg";
+      if (name.endsWith(".svg")) return "image/svg+xml";
+      return "application/octet-stream";
+    }
+  }
 }

--- a/src/main/java/frc/robot/subsystems/swerve/Module.java
+++ b/src/main/java/frc/robot/subsystems/swerve/Module.java
@@ -77,6 +77,12 @@ public class Module {
     io.setTurnPosition(new Rotation2d());
   }
 
+  /** Runs a steer-only SysId sweep while keeping the drive stage disabled. */
+  public void runTurnCharacterization(double output) {
+    io.setDriveOpenLoop(0.0);
+    io.setTurnOpenLoop(output);
+  }
+
   /** Disables all outputs to motors. */
   public void stop() {
     io.setDriveOpenLoop(0.0);

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveConstants.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveConstants.java
@@ -189,6 +189,7 @@ public final class SwerveConstants {
         case SIMBOT -> new Gains(8.0, 0.0, 0.0);
         case CRESCENDO -> new Gains(2.0, 0.0, 0.0);
       };
+
   /** Radians */
   static final double ROTATOR_PID_MIN_INPUT = 0;
   /** Radians */


### PR DESCRIPTION
## Summary
  - modernize the Reef Controls tablet UI with counters, queue management, drag reordering, and NT-backed command/spec publishing
  - introduce TabletInterfaceTracker to host the UI, translate queue requests into drive commands, and report queue state back to the dashboard
  - hook the tracker and queue topics into the robot config, add coral-station auto-alignment helpers, and split swerve SysId into drive vs. turn routines for characterization

  ## Testing
  - Only run in sim (UI/backend integration only)

  Possible next steps: 1) Test the tablet UI against a running robot to verify NT topic flow
